### PR TITLE
styles: add dark mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 # next.js
 /.next/
 /out/
+.idea
 
 # production
 /build

--- a/components/ConversationDetails.jsx
+++ b/components/ConversationDetails.jsx
@@ -320,13 +320,13 @@ export default function ConversationDetails({selectedConv, setSelectedConv, conv
 
 
   return(
-    <div className="flex flex-col h-full w-full bg-white pb-4 flex-1">
+    <div className="flex flex-col h-full w-full bg-white pb-4 flex-1 dark:bg-[#082042]">
 
        {/** List all messages in a conversation */}
        <div className="h-full overflow-hidden px-1 md:px-3">
         {loading ?
-          <div className="flex text-gray-900 w-full items-center pt-12 pb-12 flex flex-col">
-            <p className="text-slate-600 w-full text-center text-sm pb-2">Loading and decrypting your previous messages...</p>
+          <div className="flex text-gray-900 w-full items-center pt-12 pb-12 flex flex-col dark:bg-[#082042]">
+            <p className="text-slate-600 w-full text-center text-sm pb-2 dark:text-slate-400">Loading and decrypting your previous messages...</p>
             <LoadingCircle />
           </div>
         :
@@ -335,7 +335,7 @@ export default function ConversationDetails({selectedConv, setSelectedConv, conv
        </div>
 
        {/** Input to send new messages */}
-       <div className="flex flex-row items-center bg-gray-50 border-t border-slate-200 pt-3 px-3">
+       <div className="flex flex-row items-center bg-gray-50 border-t border-slate-200 pt-3 px-3 dark:bg-[#082042] dark:border-slate-700">
         {(user && user.hasLit) ?
           <>
             {hasAccess ?
@@ -347,14 +347,14 @@ export default function ConversationDetails({selectedConv, setSelectedConv, conv
                 handleInputChange={handleInputChange}
                 submit={submit} />
             :
-              <p className="text-slate-600 w-full text-center text-sm pb-1 pt-1">This app is gated based on some conditions. <span className="font-medium hover:underline text-blue-800 cursor-pointer" onClick={() => setAccessRulesModalVis(true)}>View conditions</span></p>
+              <p className="text-slate-600 w-full text-center text-sm pb-1 pt-1 dark:text-white">This app is gated based on some conditions. <span className="font-medium hover:underline text-blue-800 cursor-pointer" onClick={() => setAccessRulesModalVis(true)}>View conditions</span></p>
             }
 
           </>
         :
           <>
             <div className="flex flex-row space-x-2 w-full items-center justify-center">
-              <p className="text-slate-600 text-center text-sm"><b>Last step:</b> Setup your encryption account to get started.</p>
+              <p className="text-slate-600 text-center text-sm dark:text-white"><b>Last step:</b> Setup your encryption account to get started.</p>
               <p className="text-center">
                 <button className="btn bg-indigo-500 hover:bg-indigo-600 px-4 py-2 text-white rounded font-medium text-sm" onClick={() => connectToLit()}>Setup</button>
               </p>

--- a/components/Conversations.jsx
+++ b/components/Conversations.jsx
@@ -47,7 +47,7 @@ export default function Conversations({conversations, selectedConv, setSelectedC
   }, [user]);
 
   return(
-    <div className="flex flex-col w-full h-full py-4 -mr-4 w-96">
+    <div className="flex flex-col w-full h-full py-4 -mr-4 w-96 overflow-x-hidden dark:bg-[#041b3b] dark:text-white">
       {/** Header */}
        <div className="flex flex-row items-center pl-4 pr-4">
           <div className="flex flex-row items-center">
@@ -64,7 +64,7 @@ export default function Conversations({conversations, selectedConv, setSelectedC
           </div>
        </div>
 
-       <div className="flex-1 mt-1 overflow-y-scroll">
+       <div className="flex-1 mt-1 overflow-y-scroll overflow-x-hidden">
          {/** Conversations list or connect CTA*/}
          {user ?
            <div className="flex flex-col -mx-4 pt-4">
@@ -82,14 +82,14 @@ export default function Conversations({conversations, selectedConv, setSelectedC
                    })}
                  </>
                :
-                 <p className="text-slate-600 w-full text-center pt-6 text-sm px-12">You haven&apos;t created any conversation here yet. Try sending your first message.</p>
+                 <p className="text-slate-600 w-full text-center pt-6 text-sm px-12 dark:text-slate-500">You haven&apos;t created any conversation here yet. Try sending your first message.</p>
                }
              </>
            }
            </div>
          :
-           <div className="flex flex-col space-y-3 w-full px-12 pt-6">
-             <p className="text-slate-600 w-full text-center text-sm">You need to be connected to chat.</p>
+           <div className="flex flex-col space-y-3 w-full px-12 pt-6 dark:bg-[#041b3b]">
+             <p className="text-slate-600 w-full text-center text-sm dark:text-slate-500">You need to be connected to chat.</p>
              <p className="text-center flex justify-center">
                {connecting ?
                  <button className="btn bg-indigo-500 hover:bg-indigo-600 px-4 py-2 text-white rounded font-medium text-sm flex flex-row items-center"><LoadingCircle style={{marginRight: 8}}/> Connecting</button>
@@ -111,7 +111,7 @@ const Conversation = ({conversation, selectedConv, setSelectedConv}) => {
     return lastMessage;
   }
   return(
-    <div className={`flex flex-row items-center py-4 px-6 cursor-pointer border-y  hover:border-slate-100 hover:bg-white ${(selectedConv && selectedConv.stream_id == conversation.stream_id) ? "border-slate-200 bg-white" : "border-transparent"}`} onClick={() => setSelectedConv(conversation)}>
+    <div className={`flex flex-row items-center py-4 px-6 cursor-pointer border-y  hover:border-slate-100 hover:bg-white dark:hover:bg-slate-700 dark:hover:border-slate-600 ${(selectedConv && selectedConv.stream_id == conversation.stream_id) ? "border-slate-200 bg-white dark:bg-slate-700 dark:border-slate-600" : "border-transparent"}`} onClick={() => setSelectedConv(conversation)}>
        <div className="flex flex-col flex-grow ml-3">
           <div className="flex items-center">
              <div className="text-sm font-medium">{conversation.content.name ? conversation.content.name : "{no_name}"}</div>

--- a/components/Icons.jsx
+++ b/components/Icons.jsx
@@ -1,60 +1,109 @@
+import React from "react";
+
 export const LoadingCircle = ({style}) => {
-  return(
-    <svg className="animate-spin -ml-1 h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" style={style}>
-      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-    </svg>
-  )
+    return (
+        <svg className="animate-spin -ml-1 h-5 w-5 dark:text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+             style={style}>
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+            <path className="opacity-75" fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+        </svg>
+    )
 }
 
 export const OrbisLogo = ({width = "31", height = "41"}) => {
-  return(
-    <svg width={width} height={height} viewBox="0 0 40 53" fill="none" xmlns="http://www.w3.org/2000/svg">
-       <circle cx="20" cy="20" r="18" stroke="#fff" stroke-width="3.4"/>
-       <circle cx="20" cy="39.1304" r="11.0435" stroke="#fff" stroke-width="3.4"/>
-   </svg>
- );
+    return (
+        <svg width={width} height={height} viewBox="0 0 40 53" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="20" cy="20" r="18" stroke="#fff" stroke-width="3.4"/>
+            <circle cx="20" cy="39.1304" r="11.0435" stroke="#fff" stroke-width="3.4"/>
+        </svg>
+    );
 }
 
 export const MenuDots = () => {
-  return(
-    <svg width="4" height="14" viewBox="0 0 4 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M2 0C2.82843 0 3.5 0.671573 3.5 1.5C3.5 2.32843 2.82843 3 2 3C1.17157 3 0.5 2.32843 0.5 1.5C0.5 0.671573 1.17157 0 2 0Z" fill="currentColor"/>
-      <path d="M2 5.5C2.82843 5.5 3.5 6.17157 3.5 7C3.5 7.82843 2.82843 8.5 2 8.5C1.17157 8.5 0.5 7.82843 0.5 7C0.5 6.17157 1.17157 5.5 2 5.5Z" fill="currentColor"/>
-      <path d="M3.5 12.5C3.5 11.6716 2.82843 11 2 11C1.17157 11 0.5 11.6716 0.5 12.5C0.5 13.3284 1.17157 14 2 14C2.82843 14 3.5 13.3284 3.5 12.5Z" fill="currentColor"/>
-    </svg>
-  )
+    return (
+        <svg width="4" height="14" viewBox="0 0 4 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path
+                d="M2 0C2.82843 0 3.5 0.671573 3.5 1.5C3.5 2.32843 2.82843 3 2 3C1.17157 3 0.5 2.32843 0.5 1.5C0.5 0.671573 1.17157 0 2 0Z"
+                fill="currentColor"/>
+            <path
+                d="M2 5.5C2.82843 5.5 3.5 6.17157 3.5 7C3.5 7.82843 2.82843 8.5 2 8.5C1.17157 8.5 0.5 7.82843 0.5 7C0.5 6.17157 1.17157 5.5 2 5.5Z"
+                fill="currentColor"/>
+            <path
+                d="M3.5 12.5C3.5 11.6716 2.82843 11 2 11C1.17157 11 0.5 11.6716 0.5 12.5C0.5 13.3284 1.17157 14 2 14C2.82843 14 3.5 13.3284 3.5 12.5Z"
+                fill="currentColor"/>
+        </svg>
+    )
 }
 
 export const TwitterIcon = () => {
-  return(
-    <svg className="h-9 w-9 fill-current" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
-      <path d="M24 11.5c-.6.3-1.2.4-1.9.5.7-.4 1.2-1 1.4-1.8-.6.4-1.3.6-2.1.8-.6-.6-1.5-1-2.4-1-1.7 0-3.2 1.5-3.2 3.3 0 .3 0 .5.1.7-2.7-.1-5.2-1.4-6.8-3.4-.3.5-.4 1-.4 1.7 0 1.1.6 2.1 1.5 2.7-.5 0-1-.2-1.5-.4 0 1.6 1.1 2.9 2.6 3.2-.3.1-.6.1-.9.1-.2 0-.4 0-.6-.1.4 1.3 1.6 2.3 3.1 2.3-1.1.9-2.5 1.4-4.1 1.4H8c1.5.9 3.2 1.5 5 1.5 6 0 9.3-5 9.3-9.3v-.4c.7-.5 1.3-1.1 1.7-1.8z" />
-    </svg>
-  )
+    return (
+        <svg className="h-9 w-9 fill-current" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+            <path
+                d="M24 11.5c-.6.3-1.2.4-1.9.5.7-.4 1.2-1 1.4-1.8-.6.4-1.3.6-2.1.8-.6-.6-1.5-1-2.4-1-1.7 0-3.2 1.5-3.2 3.3 0 .3 0 .5.1.7-2.7-.1-5.2-1.4-6.8-3.4-.3.5-.4 1-.4 1.7 0 1.1.6 2.1 1.5 2.7-.5 0-1-.2-1.5-.4 0 1.6 1.1 2.9 2.6 3.2-.3.1-.6.1-.9.1-.2 0-.4 0-.6-.1.4 1.3 1.6 2.3 3.1 2.3-1.1.9-2.5 1.4-4.1 1.4H8c1.5.9 3.2 1.5 5 1.5 6 0 9.3-5 9.3-9.3v-.4c.7-.5 1.3-1.1 1.7-1.8z"/>
+        </svg>
+    )
 }
 
 export const GithubIcon = () => {
-  return(
-    <svg className="h-10 w-10 fill-current" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
-      <path d="M16 8.2c-4.4 0-8 3.6-8 8 0 3.5 2.3 6.5 5.5 7.6.4.1.5-.2.5-.4V22c-2.2.5-2.7-1-2.7-1-.4-.9-.9-1.2-.9-1.2-.7-.5.1-.5.1-.5.8.1 1.2.8 1.2.8.7 1.3 1.9.9 2.3.7.1-.5.3-.9.5-1.1-1.8-.2-3.6-.9-3.6-4 0-.9.3-1.6.8-2.1-.1-.2-.4-1 .1-2.1 0 0 .7-.2 2.2.8.6-.2 1.3-.3 2-.3s1.4.1 2 .3c1.5-1 2.2-.8 2.2-.8.4 1.1.2 1.9.1 2.1.5.6.8 1.3.8 2.1 0 3.1-1.9 3.7-3.7 3.9.3.4.6.9.6 1.6v2.2c0 .2.1.5.6.4 3.2-1.1 5.5-4.1 5.5-7.6-.1-4.4-3.7-8-8.1-8z" />
-    </svg>
-  )
+    return (
+        <svg className="h-10 w-10 fill-current" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+            <path
+                d="M16 8.2c-4.4 0-8 3.6-8 8 0 3.5 2.3 6.5 5.5 7.6.4.1.5-.2.5-.4V22c-2.2.5-2.7-1-2.7-1-.4-.9-.9-1.2-.9-1.2-.7-.5.1-.5.1-.5.8.1 1.2.8 1.2.8.7 1.3 1.9.9 2.3.7.1-.5.3-.9.5-1.1-1.8-.2-3.6-.9-3.6-4 0-.9.3-1.6.8-2.1-.1-.2-.4-1 .1-2.1 0 0 .7-.2 2.2.8.6-.2 1.3-.3 2-.3s1.4.1 2 .3c1.5-1 2.2-.8 2.2-.8.4 1.1.2 1.9.1 2.1.5.6.8 1.3.8 2.1 0 3.1-1.9 3.7-3.7 3.9.3.4.6.9.6 1.6v2.2c0 .2.1.5.6.4 3.2-1.1 5.5-4.1 5.5-7.6-.1-4.4-3.7-8-8.1-8z"/>
+        </svg>
+    )
 }
 
 export const SendIcon = () => {
-  return(
-    <svg
-       className="w-5 h-5 transform rotate-90 -mr-px"
-       fill="none"
-       stroke="currentColor"
-       viewBox="0 0 24 24"
-       xmlns="http://www.w3.org/2000/svg">
-       <path stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8">
-       </path>
-    </svg>
-  )
+    return (
+        <svg
+            className="w-5 h-5 transform rotate-90 -mr-px"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg">
+            <path stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8">
+            </path>
+        </svg>
+    )
+}
+
+export const DarkModeIcon = () => {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            stroke="currentColor"
+            className="w-4 h-4 text-white dark:text-white"
+        >
+            <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
+            />
+        </svg>
+    )
+}
+export const LightModeIcon = () => {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            stroke="currentColor"
+            className="w-4 h-4 text-white dark:text-white"
+        >
+            <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
+            />
+        </svg>
+    )
 }

--- a/components/Message.jsx
+++ b/components/Message.jsx
@@ -10,10 +10,10 @@ export default function Message({message, sent}) {
     return(
       <div className="ml-[20%] md:ml-[40%] p-3 rounded-lg">
          <div className="flex items-start flex-row-reverse">
-            <div className="flex w-[60px]">
+            <div className="flex">
               <UserPfp details={user} />
             </div>
-            <div className="relative mr-3 text-sm bg-indigo-100 py-2 px-4 border border-indigo-300 rounded-xl space-y-3 message-content" dangerouslySetInnerHTML={{__html: marked.parse(message.content)}}></div>
+            <div className="relative mr-3 text-sm bg-indigo-100 py-2 px-4 border border-indigo-300 rounded-xl space-y-3 message-content dark:bg-indigo-800 dark:text-white dark:border-indigo-600" dangerouslySetInnerHTML={{__html: marked.parse(message.content)}}></div>
          </div>
       </div>
     )
@@ -24,7 +24,7 @@ export default function Message({message, sent}) {
             <div className="hidden md:flex items-center justify-center h-10 w-10 rounded-full bg-indigo-500 flex-shrink-0">
               <OrbisLogo width="21" height="28" />
             </div>
-            <div className="relative md:ml-3 text-sm bg-white py-2 px-4 border border-slate-200 rounded-xl space-y-3 message-content" dangerouslySetInnerHTML={{__html: marked.parse(message.content)}}></div>
+            <div className="relative md:ml-3 text-sm bg-white py-2 px-4 border border-slate-200 rounded-xl space-y-3 message-content dark:bg-slate-600 dark:text-white dark:border-slate-700" dangerouslySetInnerHTML={{__html: marked.parse(message.content)}}></div>
          </div>
       </div>
     );

--- a/components/MessageInput.jsx
+++ b/components/MessageInput.jsx
@@ -23,7 +23,7 @@ export default function MessageInput({ message, handleKeyDown, handleInputChange
             disabled={submitting}
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
-            className={`w-full border bg-white border border-slate-200 focus:border-sky-500 flex flex-1 w-full focus:outline-none text-sm flex items-center rounded-3xl min-h-12 px-5 py-3 ${submitting ? "bg-slate-100" : "bg-white" }`} placeholder="Type your message...." />
+            className={`w-full border bg-white border border-slate-200 focus:border-sky-500 flex flex-1 w-full focus:outline-none text-sm flex items-center rounded-3xl min-h-12 px-5 py-3 dark:bg-[#041b3b] dark:text-white dark:focus:border-sky-900 ${submitting ? "bg-slate-100" : "bg-white" }`} placeholder="Type your message...." />
           <button className="flex items-center justify-center h-10 w-10 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white ml-3" onClick={() => submit()}>
             {submitting ?
               <LoadingCircle/>

--- a/components/Messages.jsx
+++ b/components/Messages.jsx
@@ -2,7 +2,7 @@ import Message from "./Message";
 
 export default function Messages({messages, currentResponse}) {
   return(
-    <div className="flex flex-col-reverse space-y-1 overflow-scroll h-full overflow-y-auto">
+    <div className="flex flex-col-reverse space-y-1 overflow-scroll h-full overflow-y-auto overflow-x-hidden">
       {/** Display current response if any */}
       {currentResponse &&
         <Message message={{role: "assistant", content: currentResponse}} />
@@ -27,7 +27,7 @@ export default function Messages({messages, currentResponse}) {
           })}
         </>
       :
-        <p className="text-slate-600 w-full text-center pb-12 text-sm">There aren&apos;t any messages in this conversation yet.</p>
+        <p className="text-slate-600 w-full text-center pb-12 text-sm dark:text-slate-500">There aren&apos;t any messages in this conversation yet.</p>
       }
     </div>
   )

--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -1,144 +1,175 @@
-import React, { useState, useEffect, useRef, useContext } from 'react';
-import { Orbis, useOrbis, UserPfp, UserPopup } from "@orbisclub/components";
-import { OrbisLogo, GithubIcon, TwitterIcon } from "./Icons";
+import React, {useState, useEffect, useRef, useContext} from 'react';
+import {Orbis, useOrbis, UserPfp, UserPopup} from "@orbisclub/components";
+import {OrbisLogo, GithubIcon, TwitterIcon, LightModeIcon, DarkModeIcon} from "./Icons";
 import useOutsideClick from "../hooks/useOutsideClick";
 import Link from 'next/link'
 import BackgroundWrapper from "./BackgroundWrapper";
-
+import {useTheme} from "next-themes";
 
 export default function Sidebar({showDiscussionPane, setShowDiscussionPane}) {
-  const { orbis, user } = useOrbis();
-  const [showUserMenu, setShowUserMenu] = useState(false);
-  const [hasUnreadMessages, setHasUnreadMessages] = useState(false);
+    const {orbis, user} = useOrbis();
+    const [showUserMenu, setShowUserMenu] = useState(false);
+    const [hasUnreadMessages, setHasUnreadMessages] = useState(false);
+    const {theme, setTheme} = useTheme();
 
-  useEffect(() => {
-    getLastTimeRead();
+    useEffect(() => {
+        getLastTimeRead();
 
-    async function getLastTimeRead() {
-      /** Retrieve last post tiemstamp for this context */
-      let { data, error } = await orbis.getContext(global.orbis_chat_context);
+        async function getLastTimeRead() {
+            /** Retrieve last post tiemstamp for this context */
+            let {data, error} = await orbis.getContext(global.orbis_chat_context);
 
-      /** Retrieve last read time for user */
-      let last_read = localStorage.getItem(global.orbis_chat_context + "-last-read");
-      if(last_read) {
-        last_read = parseInt(last_read);
-      } else {
-        last_read = 0;
-      }
-      console.log("last_read:", last_read);
-      console.log("data.last_post_timestamp:", data.last_post_timestamp);
+            /** Retrieve last read time for user */
+            let last_read = localStorage.getItem(global.orbis_chat_context + "-last-read");
+            if (last_read) {
+                last_read = parseInt(last_read);
+            } else {
+                last_read = 0;
+            }
+            console.log("last_read:", last_read);
+            console.log("data.last_post_timestamp:", data.last_post_timestamp);
 
-        /** Show unread messages indicator if applicable */
-      if(data && data.last_post_timestamp && (data.last_post_timestamp > last_read)) {
-        setHasUnreadMessages(true);
-      }
+            /** Show unread messages indicator if applicable */
+            if (data && data.last_post_timestamp && (data.last_post_timestamp > last_read)) {
+                setHasUnreadMessages(true);
+            }
+        }
+    }, []);
+
+    /** Open community chat and reset new message indicator */
+    function openCommunityChat() {
+        setShowDiscussionPane(true);
+        setHasUnreadMessages(false);
     }
-  }, []);
 
-  /** Open community chat and reset new message indicator */
-  function openCommunityChat() {
-    setShowDiscussionPane(true);
-    setHasUnreadMessages(false);
-  }
-
-  return(
-    <div className="relative flex flex-col items-center py-4 flex-shrink-0 w-20 bg-[#051224] rounded-3xl">
-       <a href="#" className="flex items-center justify-center mt-1">
-         <OrbisLogo />
-       </a>
-       <ul className="flex flex-1 flex-col space-y-2 mt-6">
-          <li>
-             <Link href="/" className="flex items-center">
-                <span className="flex items-center justify-center text-indigo-100 hover:bg-[#101d30] h-12 w-12 rounded-2xl">
+    return (
+        <div className="relative flex flex-col items-center py-4 flex-shrink-0 w-20 bg-[#051224] rounded-3xl">
+            <a href="#" className="flex items-center justify-center mt-1">
+                <OrbisLogo/>
+            </a>
+            <ul className="flex flex-1 flex-col space-y-2 mt-6">
+                <li>
+                    <Link href="/" className="flex items-center">
+                <span
+                    className="flex items-center justify-center text-indigo-100 hover:bg-[#101d30] h-12 w-12 rounded-2xl">
                   <svg width="22" height="21" viewBox="0 0 22 21" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M1.25 11L10.2045 2.04549C10.6438 1.60615 11.3562 1.60615 11.7955 2.04549L20.75 11M3.5 8.75V18.875C3.5 19.4963 4.00368 20 4.625 20H8.75V15.125C8.75 14.5037 9.25368 14 9.875 14H12.125C12.7463 14 13.25 14.5037 13.25 15.125V20H17.375C17.9963 20 18.5 19.4963 18.5 18.875V8.75M7.25 20H15.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                    <path
+                        d="M1.25 11L10.2045 2.04549C10.6438 1.60615 11.3562 1.60615 11.7955 2.04549L20.75 11M3.5 8.75V18.875C3.5 19.4963 4.00368 20 4.625 20H8.75V15.125C8.75 14.5037 9.25368 14 9.875 14H12.125C12.7463 14 13.25 14.5037 13.25 15.125V20H17.375C17.9963 20 18.5 19.4963 18.5 18.875V8.75M7.25 20H15.5"
+                        stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
                   </svg>
                 </span>
-             </Link>
-          </li>
+                    </Link>
+                </li>
 
-          <li>
-             <div className="flex items-center">
-                <span className="relative flex items-center justify-center text-indigo-100 hover:bg-[#101d30] h-12 w-12 rounded-2xl cursor-pointer" onClick={() => openCommunityChat()}>
+                <li>
+                    <div className="flex items-center">
+                <span
+                    className="relative flex items-center justify-center text-indigo-100 hover:bg-[#101d30] h-12 w-12 rounded-2xl cursor-pointer"
+                    onClick={() => openCommunityChat()}>
                   <svg width="22" height="20" viewBox="0 0 22 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M19.25 6.51104C20.1341 6.79549 20.75 7.6392 20.75 8.60822V12.8938C20.75 14.0304 19.9026 14.9943 18.7697 15.0867C18.4308 15.1144 18.0909 15.1386 17.75 15.1592V18.25L14.75 15.25C13.3963 15.25 12.0556 15.1948 10.7302 15.0866C10.4319 15.0623 10.1534 14.9775 9.90494 14.8451M19.25 6.51104C19.0986 6.46232 18.9393 6.43 18.7739 6.41628C17.4472 6.30616 16.1051 6.25 14.75 6.25C13.3948 6.25 12.0528 6.30616 10.7261 6.41627C9.59499 6.51015 8.75 7.47323 8.75 8.60821V12.8937C8.75 13.731 9.20986 14.4746 9.90494 14.8451M19.25 6.51104V4.63731C19.25 3.01589 18.0983 1.61065 16.4903 1.40191C14.4478 1.13676 12.365 1 10.2503 1C8.13533 1 6.05233 1.13678 4.00963 1.40199C2.40173 1.61074 1.25 3.01598 1.25 4.63738V10.8626C1.25 12.484 2.40173 13.8893 4.00964 14.098C4.58661 14.1729 5.16679 14.2376 5.75 14.2918V19L9.90494 14.8451" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                    <path
+                        d="M19.25 6.51104C20.1341 6.79549 20.75 7.6392 20.75 8.60822V12.8938C20.75 14.0304 19.9026 14.9943 18.7697 15.0867C18.4308 15.1144 18.0909 15.1386 17.75 15.1592V18.25L14.75 15.25C13.3963 15.25 12.0556 15.1948 10.7302 15.0866C10.4319 15.0623 10.1534 14.9775 9.90494 14.8451M19.25 6.51104C19.0986 6.46232 18.9393 6.43 18.7739 6.41628C17.4472 6.30616 16.1051 6.25 14.75 6.25C13.3948 6.25 12.0528 6.30616 10.7261 6.41627C9.59499 6.51015 8.75 7.47323 8.75 8.60821V12.8937C8.75 13.731 9.20986 14.4746 9.90494 14.8451M19.25 6.51104V4.63731C19.25 3.01589 18.0983 1.61065 16.4903 1.40191C14.4478 1.13676 12.365 1 10.2503 1C8.13533 1 6.05233 1.13678 4.00963 1.40199C2.40173 1.61074 1.25 3.01598 1.25 4.63738V10.8626C1.25 12.484 2.40173 13.8893 4.00964 14.098C4.58661 14.1729 5.16679 14.2376 5.75 14.2918V19L9.90494 14.8451"
+                        stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
                   </svg>
 
-                  {/** Show unread messages indicator if any */}
-                  {hasUnreadMessages &&
-                    <div className="bg-red-500 absolute h-2.5 w-2.5 rounded-full top-[7px] right-[7px]"></div>
-                  }
+                    {/** Show unread messages indicator if any */}
+                    {hasUnreadMessages &&
+                        <div className="bg-red-500 absolute h-2.5 w-2.5 rounded-full top-[7px] right-[7px]"></div>
+                    }
                 </span>
-             </div>
-          </li>
-       </ul>
+                    </div>
+                </li>
+                <li>
+                    <div className="flex items-center">
+                   <span
+                       className="flex items-center justify-center text-indigo-100 hover:bg-[#101d30] h-12 w-12 rounded-2xl">
+                       <button
+                           aria-label="Toggle Dark Mode"
+                           type="button"
+                           className="w-10 h-10 p-3 rounded focus:outline-none"
+                           onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+                       >
+                {theme === "dark" ? <LightModeIcon/> : <DarkModeIcon/>}
+                    </button>
+                   </span>
+                    </div>
+                </li>
+            </ul>
 
-       {/** External links */}
-       <ul className="mb-3">
-         <li>
-            <Link href="https://github.com/OrbisWeb3/orbis-chat-gpt" target="_blank"
-               className="flex items-center">
-               <span className="flex items-center justify-center text-indigo-100 hover:bg-[#101d30] h-12 w-12 rounded-2xl">
-                 <GithubIcon />
+            {/** External links */}
+            <ul className="mb-3">
+                <li>
+                    <Link href="https://github.com/OrbisWeb3/orbis-chat-gpt" target="_blank"
+                          className="flex items-center">
+               <span
+                   className="flex items-center justify-center text-indigo-100 hover:bg-[#101d30] h-12 w-12 rounded-2xl">
+                 <GithubIcon/>
                </span>
-            </Link>
-         </li>
-         <li>
-            <Link href="https://twitter.com/useOrbis" target="_blank"
-               className="flex items-center">
-               <span className="flex items-center justify-center text-indigo-100 hover:bg-[#101d30] h-12 w-12 rounded-2xl">
-                 <TwitterIcon />
+                    </Link>
+                </li>
+                <li>
+                    <Link href="https://twitter.com/useOrbis" target="_blank"
+                          className="flex items-center">
+               <span
+                   className="flex items-center justify-center text-indigo-100 hover:bg-[#101d30] h-12 w-12 rounded-2xl">
+                 <TwitterIcon/>
                </span>
-            </Link>
-         </li>
-       </ul>
+                    </Link>
+                </li>
+            </ul>
 
-       {/** Show connected user on bottom left */}
-       {user &&
-         <div className="cursor-pointer flex" onClick={() => setShowUserMenu(true)}>
-            <UserPfp details={user} />
-         </div>
-       }
+            {/** Show connected user on bottom left */}
+            {user &&
+                <div className="cursor-pointer flex" onClick={() => setShowUserMenu(true)}>
+                    <UserPfp details={user}/>
+                </div>
+            }
 
-       {/** Showing user menu */}
-       {showUserMenu &&
-         <UserMenuVertical hide={() => setShowUserMenu(false)} />
-       }
-    </div>
-  )
+            {/** Showing user menu */}
+            {showUserMenu &&
+                <UserMenuVertical hide={() => setShowUserMenu(false)}/>
+            }
+        </div>
+    )
 }
 
 /** User menu with update profile and logout buttons */
 const UserMenuVertical = ({hide}) => {
-  const { orbis, user, setUser, setConnectModalVis } = useOrbis();
-  const [showUserPopup, setShowUserPopup] = useState(false);
-  const wrapperRef = useRef(null);
+    const {orbis, user, setUser, setConnectModalVis} = useOrbis();
+    const [showUserPopup, setShowUserPopup] = useState(false);
+    const wrapperRef = useRef(null);
 
-  /** Is triggered when clicked outside the component */
-  useOutsideClick(wrapperRef, () => hide());
+    /** Is triggered when clicked outside the component */
+    useOutsideClick(wrapperRef, () => hide());
 
-  async function logout() {
-    let res = await orbis.logout();
-    setUser(null);
-    hide();
-  }
+    async function logout() {
+        let res = await orbis.logout();
+        setUser(null);
+        hide();
+    }
 
-  return(
-    <>
-      <div className="absolute bottom-[0px] left-[50px] py-10 z-50 w-[165px]">
-        <div className="text-sm shadow-md bg-white border border-gray-200 p-3 rounded-md flex flex-col w-full space-y-1" ref={wrapperRef}>
-          <div className="text-primary font-medium hover:bg-gray-50 cursor-pointer rounded py-1.5 px-2" onClick={() => setShowUserPopup(true)}>Update profile</div>
-          <div className="text-primary font-medium hover:bg-gray-50 cursor-pointer rounded py-1.5 px-2" onClick={() => logout()}>Logout</div>
+    return (
+        <>
+            <div className="absolute bottom-[0px] left-[50px] py-10 z-50 w-[165px]">
+                <div
+                    className="text-sm shadow-md bg-white border border-gray-200 p-3 rounded-md flex flex-col w-full space-y-1"
+                    ref={wrapperRef}>
+                    <div className="text-primary font-medium hover:bg-gray-50 cursor-pointer rounded py-1.5 px-2"
+                         onClick={() => setShowUserPopup(true)}>Update profile
+                    </div>
+                    <div className="text-primary font-medium hover:bg-gray-50 cursor-pointer rounded py-1.5 px-2"
+                         onClick={() => logout()}>Logout
+                    </div>
 
-          {showUserPopup &&
-            <BackgroundWrapper hide={() => setShowUserPopup(false)}>
-              <div className="flex pointer-events-auto w-screen justify-center">
-                <UserPopup details={user} position="relative" />
-              </div>
-            </BackgroundWrapper>
-          }
-        </div>
-      </div>
-    </>
-  )
+                    {showUserPopup &&
+                        <BackgroundWrapper hide={() => setShowUserPopup(false)}>
+                            <div className="flex pointer-events-auto w-screen justify-center">
+                                <UserPopup details={user} position="relative"/>
+                            </div>
+                        </BackgroundWrapper>
+                    }
+                </div>
+            </div>
+        </>
+    )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "https": "^1.0.0",
         "marked": "^4.3.0",
         "next": "13.2.4",
+        "next-themes": "^0.2.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-textarea-autosize": "^8.4.1",
@@ -20149,6 +20150,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.2.1.tgz",
+      "integrity": "sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==",
+      "peerDependencies": {
+        "next": "*",
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/next-tick": {
@@ -48443,6 +48454,12 @@
           }
         }
       }
+    },
+    "next-themes": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.2.1.tgz",
+      "integrity": "sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==",
+      "requires": {}
     },
     "next-tick": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "https": "^1.0.0",
     "marked": "^4.3.0",
     "next": "13.2.4",
+    "next-themes": "^0.2.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-textarea-autosize": "^8.4.1",

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,33 +1,38 @@
 import '@/styles/globals.css'
-import { Orbis, OrbisProvider } from "@orbisclub/components";
+import {Orbis, OrbisProvider} from "@orbisclub/components";
 import "@orbisclub/components/dist/index.modern.css";
 import Script from 'next/script'
+import {ThemeProvider} from "next-themes";
 
 /** Set the global forum context here. You can create your context here: https://useorbis.com/dashboard */
 global.orbis_context = "kjzl6cwe1jw14b06s2ppzmc62rrf4a2cmck0612il3g5ga8w9s67xu7icjo6arz";
 global.orbis_chat_context = "kjzl6cwe1jw14bixqvv1zj647a707e962fc39awh749lok3ivo3tfog1o2n44zd";
 
 let orbis = new Orbis({
-  useLit: true,
-  node: "https://node2.orbis.club"
+    useLit: true,
+    node: "https://node2.orbis.club"
 });
 
-export default function App({ Component, pageProps }) {
-  return (
-    <>
-      <Script
-        src="https://www.googletagmanager.com/gtag/js?id=G-8QVH2K5MJP"
-        strategy="afterInteractive"
-      />
-      <Script id="google-analytics" strategy="afterInteractive">
-        {`
+export default function App({Component, pageProps}) {
+    return (
+        <>
+            <Script
+                src="https://www.googletagmanager.com/gtag/js?id=G-8QVH2K5MJP"
+                strategy="afterInteractive"
+            />
+            <Script id="google-analytics" strategy="afterInteractive">
+                {`
           window.dataLayer = window.dataLayer || [];
           function gtag(){window.dataLayer.push(arguments);}
           gtag('js', new Date());
           gtag('config', 'G-8QVH2K5MJP');
         `}
-      </Script>
-      <OrbisProvider defaultOrbis={orbis}><Component {...pageProps} /></OrbisProvider>
-    </>
-  );
+            </Script>
+            <OrbisProvider defaultOrbis={orbis}>
+                <ThemeProvider defaultTheme="light" attribute="class">
+                    <Component {...pageProps} />
+                </ThemeProvider>
+            </OrbisProvider>
+        </>
+    );
 }

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -34,7 +34,7 @@ export default function Home() {
       </Head>
       <main className="h-screen overflow-hidden flex items-center justify-center bg-[#edf2f7] w-full">
         <div className="flex flex-row h-screen antialiased text-gray-800 w-full">
-           <div className="hidden md:flex flex-row flex-shrink-0 bg-slate-50 border-r border-slate-200 p-4 w-[360px]">
+           <div className="hidden md:flex flex-row flex-shrink-0 bg-slate-50 border-r border-slate-200 p-4 w-[360px] dark:bg-[#041b3b]">
               {/** Global playground sidebar on the left */}
               <Sidebar setShowDiscussionPane={setShowDiscussionPane} />
 
@@ -54,8 +54,8 @@ export default function Home() {
                 setSelectedConv={setSelectedConv}
                 selectedConv={selectedConv} />
            :
-              <div className="flex flex-col space-y-3 w-full">
-                <p className="text-slate-600 w-full text-center pt-12 text-sm">You need to be connected to chat.</p>
+              <div className="flex flex-col space-y-3 w-full dark:bg-[#041b3b]">
+                <p className="text-slate-600 w-full text-center pt-12 text-sm dark:text-white">You need to be connected to chat.</p>
                 <p className="text-center flex justify-center">
                   {connecting ?
                     <button className="btn bg-indigo-500 hover:bg-indigo-600 px-4 py-2 text-white rounded font-medium text-sm flex flex-row items-center"><LoadingCircle style={{marginRight: 8}}/> Connecting</button>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -79,6 +79,37 @@
   --card-border-rgb: 131, 134, 135;
 }
 
+[data-theme='dark'] {
+    --foreground-rgb: 255, 255, 255;
+    --background-start-rgb: 0, 0, 0;
+    --background-end-rgb: 0, 0, 0;
+
+    --primary-glow: radial-gradient(rgba(1, 65, 255, 0.4), rgba(1, 65, 255, 0));
+    --secondary-glow: linear-gradient(
+        to bottom right,
+        rgba(1, 65, 255, 0),
+        rgba(1, 65, 255, 0),
+        rgba(1, 65, 255, 0.3)
+    );
+
+    --tile-start-rgb: 2, 13, 46;
+    --tile-end-rgb: 2, 5, 19;
+    --tile-border: conic-gradient(
+        #ffffff80,
+        #ffffff40,
+        #ffffff30,
+        #ffffff20,
+        #ffffff10,
+        #ffffff10,
+        #ffffff80
+    );
+
+    --callout-rgb: 20, 20, 20;
+    --callout-border-rgb: 108, 108, 108;
+    --card-rgb: 100, 100, 100;
+    --card-border-rgb: 200, 200, 200;
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     --foreground-rgb: 255, 255, 255;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: "class",
   content: [
     "./app/**/*.{js,ts,jsx,tsx}",
     "./pages/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
This pull request adds dark mode functionality to the project. Users can now toggle between light and dark mode by clicking on the switch button in the sidebar.

Changes made:
- Added 2 new icons `DarkModeIcon` and `LightModeIcon` component that renders an SVG for the switch and handles state changes.
- Added tailwind `dark:` classes to appropriate places
- Added `next-themes` to handle the state changes.

Screenshots: 
![no-conversation-selected](https://bafkreif4q4ncygi4asdod4k6psizwwwon3hr2rwhfqzr4n4cp4ednulzhe.ipfs.nftstorage.link/)

![conversation-selected](https://bafybeids5axixfjq622mqxnaelolkgf2xntjkgpjilbozdea5yw2sbjan4.ipfs.nftstorage.link/)

Dependencies: 
- `next-themes`

To test:
- Run the app locally and test the dark mode switch.

Please review and let me know if there are any changes you'd like me to make. Thank you!
